### PR TITLE
Rename `duplicate` to `extend` in Conway GoL comonad implementation

### DIFF
--- a/_posts/conway-aol-with-comonads/2021-04-29-conway-aol-with-comonads.markdown
+++ b/_posts/conway-aol-with-comonads/2021-04-29-conway-aol-with-comonads.markdown
@@ -118,8 +118,8 @@ Shall we implement `Comonad` type class? Let's try implement `extract`.
 extract :: Store s a -> a
 extract (Store idx get) = get idx
 
-duplicate :: (Store s a -> b) -> Store s a -> Store s b
-duplicate f (Store idx get) = Store idx (\i -> f (Store i get))
+extend :: (Store s a -> b) -> Store s a -> Store s b
+extend f (Store idx get) = Store idx (\i -> f (Store i get))
 ```
 You can compare this implementation with the explanation of `extend` above.
 


### PR DESCRIPTION
I enjoyed the "Brief introduction to Conway Game of Life with Comonads" article very much and would like to contribute by fixing this small error in the naming of the methods in the comonad implementation.